### PR TITLE
Add Plugin Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This project is a continuation of YAWAST, as yawast-ng, to continue the project 
 * [Scanning TLS/SSL](https://numorian.github.io/yawast-ng/tls/)
   * [OpenSSL & 3DES Compatibility](https://numorian.github.io/yawast-ng/openssl/)
 * [Sample Output](https://numorian.github.io/yawast-ng/sample/)
+* [Plugins](https://numorian.github.io/yawast-ng/plugins/)
 * [FAQ](https://numorian.github.io/yawast-ng/faq/)
 
 Please see [the project website](https://numorian.github.io/yawast-ng/) for full documentation.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,51 +1,59 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-US" }}">
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="{{ site.lang | default: " en-US" }}">
 
-{% seo %}
-    <link rel="stylesheet" href="{{ "/assets/css/stylec.css?v=" | append: site.github.build_revision | relative_url }}">
-    <!--[if lt IE 9]>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  {% seo %}
+  <link rel="stylesheet" href="{{ " /assets/css/stylec.css?v=" | append: site.github.build_revision | relative_url }}">
+  <!--[if lt IE 9]>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
-  </head>
-  <body>
-    <div class="wrapper">
-      <header>
-        <h1><a href="{{ "/" | absolute_url }}"><img src="{{site.logo | relative_url}}" alt="YAWAST" width="270px" /></a></h1>
+</head>
 
-        <p>{{ site.description | default: site.github.project_tagline }}</p>
+<body>
+  <div class="wrapper">
+    <header>
+      <h1><a href="{{ " /" | absolute_url }}"><img src="{{site.logo | relative_url}}" alt="YAWAST" width="270px" /></a>
+      </h1>
 
-        <ul>
-          <li><a href="https://numorian.github.io/yawast-ng/blog/">Blog</a></li>
-          <li><a href="https://numorian.github.io/yawast-ng/installation/">Installation</a></li>
-          <li><a href="https://numorian.github.io/yawast-ng/usage/">Usage &amp; Parameters</a></li>
-          <li><a href="https://numorian.github.io/yawast-ng/checks/">Checks Performed</a></li>
-          <li><a href="https://numorian.github.io/yawast-ng/tls/">Scanning TLS / SSL</a></li>
-          <li><a href="https://numorian.github.io/yawast-ng/about/">About</a></li>
-          <li><a href="https://numorian.github.io/yawast-ng/faq/">FAQs</a></li>
-        </ul>
+      <p>{{ site.description | default: site.github.project_tagline }}</p>
 
-        {% if site.github.is_project_page %}
-        <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
-        {% endif %}
-      </header>
-      <section>
+      <ul>
+        <li><a href="https://numorian.github.io/yawast-ng/blog/">Blog</a></li>
+        <li><a href="https://numorian.github.io/yawast-ng/installation/">Installation</a></li>
+        <li><a href="https://numorian.github.io/yawast-ng/usage/">Usage &amp; Parameters</a></li>
+        <li><a href="https://numorian.github.io/yawast-ng/checks/">Checks Performed</a></li>
+        <li><a href="https://numorian.github.io/yawast-ng/tls/">Scanning TLS / SSL</a></li>
+        <li><a href="https://numorian.github.io/yawast-ng/plugins/">Plugins</a></li>
+        <li><a href="https://numorian.github.io/yawast-ng/about/">About</a></li>
+        <li><a href="https://numorian.github.io/yawast-ng/faq/">FAQs</a></li>
+      </ul>
+
+      {% if site.github.is_project_page %}
+      <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{
+            site.github.repository_nwo }}</small></a></p>
+      {% endif %}
+    </header>
+    <section>
 
       {{ content }}
 
-      </section>
-      <footer>
-        <a href="https://numorian.com"><img src="{{ "/assets/Logo.512-black-on-white.png" | relative_url }}" alt="Numorian" width="50px" style="vertical-align:middle" />
+    </section>
+    <footer>
+      <a href="https://numorian.com"><img src="{{ " /assets/Logo.512-black-on-white.png" | relative_url }}"
+          alt="Numorian" width="50px" style="vertical-align:middle" />
         <span style="vertical-align:middle">Numorian</span></a>
-        <p>yawast-ng is proudly supported by Numorian.</p>
-        
+      <p>yawast-ng is proudly supported by Numorian.</p>
 
-        <p><small>&copy; 2025 Adam Caudill - See <a href="https://github.com/Numorian/yawast-ng/blob/main/LICENSE">license</a> for details.</small></p>
-      </footer>
-    </div>
-    <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
-  </body>
+
+      <p><small>&copy; 2025 Adam Caudill - See <a
+            href="https://github.com/Numorian/yawast-ng/blob/main/LICENSE">license</a> for details.</small></p>
+    </footer>
+  </div>
+  <script src="{{ " /assets/js/scale.fix.js" | relative_url }}"></script>
+</body>
+
 </html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ Details about yawast-ng and how to use it can be found below:
 * [Scanning TLS/SSL](https://numorian.github.io/yawast-ng/tls/)
   * [OpenSSL & 3DES Compatibility](https://numorian.github.io/yawast-ng/openssl/)
 * [Sample Output](https://numorian.github.io/yawast-ng/sample/)
+* [Plugins](https://numorian.github.io/yawast-ng/plugins/)
 * [FAQ](https://numorian.github.io/yawast-ng/faq/)
 * [Change Log](https://github.com/Numorian/yawast-ng/blob/master/CHANGELOG.md)
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: The yawast-ng Plugin System
+permalink: /plugins/
+---
+
+# yawast-ng Plugin System
+
+yawast-ng supports a flexible plugin system that allows users to extend its scanning capabilities by writing and installing their own plugins. This enables custom checks, integrations, and automation tailored to your needs.
+
+## How Plugins Work
+
+Plugins are Python packages that implement a specific interface and are discovered automatically by yawast-ng at runtime. Plugins must:
+
+- Inherit from one of the base plugin classes (e.g., `ScannerPluginBase`)
+- Be installed in the same Python environment as yawast-ng
+- Register themselves using Python's `entry_points` mechanism under the `yawast.plugins` group
+
+When yawast-ng starts, it loads all installed plugins and makes them available for use during scans.
+
+## Creating a Plugin
+
+To create your own plugin:
+
+1. **Copy the Sample Plugin**
+
+Use the [sample-plugin](/sample-plugin) directory as a starting point. It contains a minimal, working example.
+
+2. **Inherit from a Plugin Base Class**
+
+Your plugin should inherit from `ScannerPluginBase` (or another appropriate base class) and implement the required methods, such as `check(self, url: str)`.
+
+Example:
+
+```python
+from yawast.scanner.plugins.scanner_plugin_base import ScannerPluginBase
+
+class MyPlugin(ScannerPluginBase):
+    def __init__(self):
+        super().__init__()
+        self.name = "MyPlugin"
+        self.description = "A custom plugin."
+        self.version = "0.1.0"
+
+    def check(self, url: str) -> None:
+        # Your scanning logic here
+        pass
+```
+
+3. **Add an Entry Point**
+
+In your `setup.py`, add an entry point under `yawast.plugins`:
+
+```python
+entry_points={
+    "yawast.plugins": [
+        "my_plugin = my_plugin:MyPlugin",
+    ],
+},
+```
+
+4. **Package and Install**
+
+Build and install your plugin package:
+
+```bash
+pip install .
+```
+
+yawast-ng will automatically discover and load your plugin the next time it runs.
+
+## Example: Sample Plugin
+
+See the [sample-plugin](https://github.com/Numorian/yawast-ng/tree/main/sample-plugin) directory for a complete, minimal example. This can be copied and modified to create your own plugins.
+
+## Tips
+
+- Use unique names for your plugin and entry point to avoid conflicts.
+- Plugins can be distributed as Python packages (e.g., via PyPI or as local packages).
+- For advanced use, see the base classes in `yawast/scanner/plugins/` for more plugin types and hooks.
+
+## Troubleshooting
+
+- Ensure your plugin is installed in the same environment as yawast-ng.
+- Check the yawast-ng output for plugin loading errors.
+- Use the `print_loaded_plugins()` function or equivalent command to verify your plugin is detected.

--- a/sample-plugin/README.md
+++ b/sample-plugin/README.md
@@ -1,0 +1,13 @@
+# Sample Plugin for yawast-ng
+
+This is a sample plugin for yawast-ng. It demonstrates how to create a simple plugin that can be used to extend the functionality of yawast-ng.
+
+## Installation
+
+Simply install this as a Python package:
+
+```bash
+pip install .
+```
+
+When yawast-ng starts, it will automatically discover and load this plugin based on the entry point defined in `setup.py`.

--- a/sample-plugin/plugin/__init__.py
+++ b/sample-plugin/plugin/__init__.py
@@ -1,0 +1,2 @@
+#  This file is a sample plugin for yawast-ng.
+#  Released under the MIT license.

--- a/sample-plugin/plugin/sample_plugin.py
+++ b/sample-plugin/plugin/sample_plugin.py
@@ -1,6 +1,9 @@
 #  This file is a sample plugin for yawast-ng.
 #  Released under the MIT license.
 
+from requests import Response
+
+from yawast.scanner.plugins.hook_scanner_base import HookScannerBase
 from yawast.scanner.plugins.scanner_plugin_base import HttpScannerPluginBase
 from yawast.shared import output
 
@@ -20,3 +23,21 @@ class SamplePlugin(HttpScannerPluginBase):
         # This is where your plugin logic goes.
         # For demonstration, we'll just print a message (avoid in real plugins).
         output.info(f"SamplePlugin checked: {url}")
+
+
+class SampleHookPlugin(HookScannerBase):
+    """
+    A sample hook plugin for yawast-ng.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "SampleHookPlugin"
+        self.description = "A sample hook plugin that demonstrates the hook interface."
+        self.version = "0.1.0"
+
+    def response_received(self, url: str, response: Response) -> None:
+        # This is where your hook logic goes.
+        # For demonstration, we'll just print a message if the response is large.
+        if len(response.content) > 1024 * 100:
+            output.info(f"SampleHookPlugin received large response: {url}")

--- a/sample-plugin/plugin/sample_plugin.py
+++ b/sample-plugin/plugin/sample_plugin.py
@@ -1,0 +1,22 @@
+#  This file is a sample plugin for yawast-ng.
+#  Released under the MIT license.
+
+from yawast.scanner.plugins.scanner_plugin_base import HttpScannerPluginBase
+from yawast.shared import output
+
+
+class SamplePlugin(HttpScannerPluginBase):
+    """
+    A simple example plugin for yawast-ng.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "SamplePlugin"
+        self.description = "A sample plugin that demonstrates the plugin interface."
+        self.version = "0.1.0"
+
+    def check(self, url: str) -> None:
+        # This is where your plugin logic goes.
+        # For demonstration, we'll just print a message (avoid in real plugins).
+        output.info(f"SamplePlugin checked: {url}")

--- a/sample-plugin/setup.py
+++ b/sample-plugin/setup.py
@@ -1,0 +1,24 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="yawast-plugin-sample",
+    version="0.1.0",
+    description="A sample plugin for yawast-ng.",
+    author="Your Name",
+    author_email="your@email.com",
+    packages=find_packages(),
+    install_requires=[
+        # Add any dependencies your plugin needs here
+    ],
+    entry_points={
+        "yawast.plugins": [
+            "yawast-plugin-sample = plugin.sample_plugin:SamplePlugin",
+        ],
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.7",
+)

--- a/sample-plugin/setup.py
+++ b/sample-plugin/setup.py
@@ -13,6 +13,7 @@ setup(
     entry_points={
         "yawast.plugins": [
             "yawast-plugin-sample = plugin.sample_plugin:SamplePlugin",
+            "yawast-plugin-sample-hook = plugin.sample_plugin:SampleHookPlugin",
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,7 @@
 from os import path
 
 # from requirementslib import Lockfile
-from setuptools import find_packages
-
-from setuptools import setup
-
+from setuptools import find_packages, setup
 
 root_path = path.dirname(path.realpath(__file__))
 
@@ -58,7 +55,7 @@ setup(
     author="Adam Caudill",
     author_email="adam@adamcaudill.com",
     license="MIT",
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests", "sample-plugin"]),
     entry_points={"console_scripts": ["yawast = yawast.__main__:main"]},
     install_requires=[
         "sslyze==6.0.0",

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -255,3 +255,73 @@ class TestPluginLoader(TestCase):
         # Should call output.error
         mock_output.error.assert_any_call(mock.ANY)
         mock_output.debug.assert_not_called()
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_other_scans_runs_other_plugins(self, mock_output):
+        # Setup a plugin that inherits from ScannerPluginBase but not Http/Network
+        class FakeOtherScanner(plugin_manager.ScannerPluginBase):
+            def __init__(self):
+                self.checked = False
+
+            def check(self, url):
+                self.checked = True
+                mock_output.debug("checked other")
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["other"] = FakeOtherScanner
+
+        plugin_manager.run_other_scans("https://example.com")
+
+        # Should call check and output.debug for start and completion
+        mock_output.debug.assert_any_call("Running other scanner plugins...")
+        mock_output.debug.assert_any_call("Plugin other completed successfully.")
+        mock_output.error.assert_not_called()
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_other_scans_skips_http_and_network_plugins(self, mock_output):
+        class FakeHttpScanner(plugin_manager.HttpScannerPluginBase):
+            def check(self, url):
+                raise Exception("Should not be called")
+
+        class FakeNetworkScanner(plugin_manager.NetworkScannerPluginBase):
+            def check(self, url):
+                raise Exception("Should not be called")
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["http"] = FakeHttpScanner
+        plugin_manager.plugins["scanner"]["net"] = FakeNetworkScanner
+
+        plugin_manager.run_other_scans("https://example.com")
+
+        # Should not call check, so no error
+        mock_output.error.assert_not_called()
+        mock_output.debug.assert_any_call("Running other scanner plugins...")
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_other_scans_handles_plugin_exception(self, mock_output):
+        class FailingOtherScanner(plugin_manager.ScannerPluginBase):
+            def check(self, url):
+                raise ValueError("fail other!")
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["fail_other"] = FailingOtherScanner
+
+        plugin_manager.run_other_scans("https://example.com")
+
+        # Should call output.error with the exception message
+        mock_output.error.assert_any_call(
+            mock.ANY  # message includes "Failed to run plugin fail_other: fail other!"
+        )
+        # Should not call debug for completion for the failing plugin
+        calls = [c[0][0] for c in mock_output.debug.call_args_list]
+        assert not any(
+            "completed successfully" in call for call in calls if "fail_other" in call
+        )
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_other_scans_no_scanner_plugins(self, mock_output):
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.run_other_scans("https://example.com")
+        # Should not call output.debug or output.error
+        mock_output.debug.assert_not_called()
+        mock_output.error.assert_not_called()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,338 @@
+import sys
+import types
+from unittest import TestCase, mock
+
+import yawast.scanner.plugins.plugin_manager as plugin_manager
+from tests import utils
+
+
+class TestPluginLoader(TestCase):
+    def make_fake_plugin_base(self, name, base):
+        return type(name, (base,), {})
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
+    def test_load_plugins_scanner_plugin(
+        self, mock_pkg_resources, mock_import_module, mock_output
+    ):
+        # Setup fake plugin class
+        FakeScannerPlugin = self.make_fake_plugin_base(
+            "FakeScannerPlugin", plugin_manager.ScannerPluginBase
+        )
+
+        # Setup fake entry point
+        fake_entry_point = mock.Mock()
+        fake_entry_point.name = "fake_scanner"
+        fake_entry_point.load.return_value = FakeScannerPlugin
+
+        # Setup pkg_resources
+        mock_pkg_resources.working_set.by_key = {
+            "yawast_plugin_test": None,
+            "other_package": None,
+        }
+        mock_pkg_resources.iter_entry_points.return_value = [fake_entry_point]
+
+        # Setup import_module to return a module with entry_points
+        fake_module = types.SimpleNamespace(entry_points=True)
+        mock_import_module.return_value = fake_module
+
+        # Clear plugins dict
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.load_plugins()
+
+        # Assert plugin loaded as scanner
+        assert "fake_scanner" in plugin_manager.plugins["scanner"]
+        assert plugin_manager.plugins["scanner"]["fake_scanner"] is FakeScannerPlugin
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
+    def test_load_plugins_hook_plugin(
+        self, mock_pkg_resources, mock_import_module, mock_output
+    ):
+        # Setup fake plugin class
+        FakeHookPlugin = self.make_fake_plugin_base(
+            "FakeHookPlugin", plugin_manager.HookScannerBase
+        )
+
+        # Setup entry point
+        fake_entry_point = mock.Mock()
+        fake_entry_point.name = "fake_hook"
+        fake_entry_point.load.return_value = FakeHookPlugin
+
+        # Setup pkg_resources
+        mock_pkg_resources.working_set.by_key = {
+            "yawast_plugin_hook": None,
+        }
+        mock_pkg_resources.iter_entry_points.return_value = [fake_entry_point]
+
+        # Setup import_module to return a module with entry_points
+        fake_module = types.SimpleNamespace(entry_points=True)
+        mock_import_module.return_value = fake_module
+
+        # Clear plugins dict
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.load_plugins()
+
+        # Assert plugin loaded as hook
+        assert "fake_hook" in plugin_manager.plugins["hook"]
+        assert plugin_manager.plugins["hook"]["fake_hook"] is FakeHookPlugin
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
+    def test_load_plugins_non_plugin_class(
+        self, mock_pkg_resources, mock_import_module, mock_output
+    ):
+        # Setup fake class not inheriting from PluginBase
+        class NotAPlugin:
+            pass
+
+        fake_entry_point = mock.Mock()
+        fake_entry_point.name = "not_a_plugin"
+        fake_entry_point.load.return_value = NotAPlugin
+
+        mock_pkg_resources.working_set.by_key = {
+            "yawast_plugin_invalid": None,
+        }
+        mock_pkg_resources.iter_entry_points.return_value = [fake_entry_point]
+
+        fake_module = types.SimpleNamespace(entry_points=True)
+        mock_import_module.return_value = fake_module
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.load_plugins()
+
+        # Should not be loaded
+        assert "not_a_plugin" not in plugin_manager.plugins["scanner"]
+        assert "not_a_plugin" not in plugin_manager.plugins["hook"]
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
+    def test_load_plugins_import_error(
+        self, mock_pkg_resources, mock_import_module, mock_output
+    ):
+        mock_pkg_resources.working_set.by_key = {
+            "yawast_plugin_broken": None,
+        }
+        mock_import_module.side_effect = Exception("Import failed")
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        with utils.capture_sys_output() as (stdout, stderr):
+            plugin_manager.load_plugins()
+
+            self.assertIn(
+                "Failed to load package yawast_plugin_broken: Import failed",
+                stdout.getvalue(),
+            )
+
+        assert not plugin_manager.plugins["scanner"]
+        assert not plugin_manager.plugins["hook"]
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
+    def test_load_plugins_no_entry_points(
+        self, mock_pkg_resources, mock_import_module, mock_output
+    ):
+        mock_pkg_resources.working_set.by_key = {
+            "yawast_plugin_noentry": None,
+        }
+        fake_module = types.SimpleNamespace()
+        mock_import_module.return_value = fake_module
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.load_plugins()
+
+        # Should not call iter_entry_points or debug
+        mock_output.debug.assert_not_called()
+
+    @mock.patch("builtins.print")
+    def test_print_loaded_plugins_with_plugins(self, mock_print):
+        # Setup fake plugin classes
+        class FakeScannerPlugin(plugin_manager.ScannerPluginBase):
+            pass
+
+        class FakeHookPlugin(plugin_manager.HookScannerBase):
+            pass
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+        plugin_manager.plugins["scanner"]["scanner1"] = FakeScannerPlugin
+        plugin_manager.plugins["hook"]["hook1"] = FakeHookPlugin
+
+        plugin_manager.print_loaded_plugins()
+
+        # Check that print was called with expected output
+        expected_calls = [
+            mock.call("Loaded scanner plugins:"),
+            mock.call(f" - scanner1: {FakeScannerPlugin.__name__}"),
+            mock.call("Loaded hook plugins:"),
+            mock.call(f" - hook1: {FakeHookPlugin.__name__}"),
+            mock.call(),
+        ]
+        mock_print.assert_has_calls(expected_calls, any_order=False)
+
+    @mock.patch("builtins.print")
+    def test_print_loaded_plugins_no_plugins(self, mock_print):
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.print_loaded_plugins()
+
+        # Should print headers and a blank line, but no plugins
+        expected_calls = [
+            mock.call("Loaded scanner plugins:"),
+            mock.call("Loaded hook plugins:"),
+            mock.call(),
+        ]
+        mock_print.assert_has_calls(expected_calls, any_order=False)
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_http_scans_runs_non_http_plugins(self, mock_output):
+        # Setup a plugin that does NOT inherit from HttpScannerPluginBase
+        class FakeScanner(plugin_manager.ScannerPluginBase):
+            def __init__(self):
+                self.checked = False
+
+            def check(self):
+                self.checked = True
+                mock_output.debug("checked")
+
+        fake_plugin = FakeScanner
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["fake"] = fake_plugin
+
+        plugin_manager.run_http_scans()
+
+        # Should call check and output.debug for start and completion
+        mock_output.debug.assert_any_call("Running scanner plugins...")
+        mock_output.debug.assert_any_call("Plugin fake completed successfully.")
+        # Should not call output.error
+        mock_output.error.assert_not_called()
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_http_scans_skips_http_plugins(self, mock_output):
+        # Setup a plugin that DOES inherit from HttpScannerPluginBase
+        class FakeHttpScanner(plugin_manager.HttpScannerPluginBase):
+            def check(self):
+                raise Exception("Should not be called")
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["http"] = FakeHttpScanner
+
+        plugin_manager.run_http_scans()
+
+        # Should not call check, so no error
+        mock_output.error.assert_not_called()
+        mock_output.debug.assert_any_call("Running scanner plugins...")
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_http_scans_handles_plugin_exception(self, mock_output):
+        # Setup a plugin that raises in check
+        class FailingScanner(plugin_manager.ScannerPluginBase):
+            def check(self):
+                raise ValueError("fail!")
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["fail"] = FailingScanner
+
+        plugin_manager.run_http_scans()
+
+        # Should call output.error with the exception message
+        mock_output.error.assert_any_call(
+            mock.ANY  # message includes "Failed to run plugin fail: fail!"
+        )
+        # Should not call debug for completion
+        calls = [c[0][0] for c in mock_output.debug.call_args_list]
+        assert not any(
+            "completed successfully" in call for call in calls if "fail" in call
+        )
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_http_scans_no_scanner_plugins(self, mock_output):
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.run_http_scans()
+        # Should not call output.debug or output.error
+        mock_output.debug.assert_not_called()
+        mock_output.error.assert_not_called()
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_network_scans_runs_network_plugins(self, mock_output):
+        # Setup a plugin that DOES inherit from NetworkScannerPluginBase
+        class FakeNetworkScanner(plugin_manager.NetworkScannerPluginBase):
+            def __init__(self):
+                self.checked = False
+
+            def check(self):
+                self.checked = True
+                mock_output.debug("checked network")
+
+        fake_plugin = FakeNetworkScanner
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["net"] = fake_plugin
+
+        plugin_manager.run_network_scans()
+
+        # Should call check and output.debug for start and completion
+        mock_output.debug.assert_any_call("Running network scanner plugins...")
+        mock_output.debug.assert_any_call("Plugin net completed successfully.")
+        mock_output.error.assert_not_called()
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_network_scans_skips_non_network_plugins(self, mock_output):
+        # Setup a plugin that does NOT inherit from NetworkScannerPluginBase
+        class FakeScanner(plugin_manager.ScannerPluginBase):
+            def check(self):
+                raise Exception("Should not be called")
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["not_net"] = FakeScanner
+
+        plugin_manager.run_network_scans()
+
+        # Should not call check, so no error
+        mock_output.error.assert_not_called()
+        mock_output.debug.assert_any_call("Running network scanner plugins...")
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_network_scans_handles_plugin_exception(self, mock_output):
+        # Setup a plugin that raises in check
+        class FailingNetworkScanner(plugin_manager.NetworkScannerPluginBase):
+            def check(self):
+                raise ValueError("fail net!")
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["scanner"]["fail_net"] = FailingNetworkScanner
+
+        plugin_manager.run_network_scans()
+
+        # Should call output.error with the exception message
+        mock_output.error.assert_any_call(
+            mock.ANY  # message includes "Failed to run plugin fail_net: fail net!"
+        )
+        # Should not call debug for completion for the failing plugin
+        calls = [c[0][0] for c in mock_output.debug.call_args_list]
+        assert not any(
+            "completed successfully" in call for call in calls if "fail_net" in call
+        )
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    def test_run_network_scans_no_scanner_plugins(self, mock_output):
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.run_network_scans()
+        # Should not call output.debug or output.error
+        mock_output.debug.assert_not_called()
+        mock_output.error.assert_not_called()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -7,158 +7,6 @@ from tests import utils
 
 
 class TestPluginLoader(TestCase):
-    def make_fake_plugin_base(self, name, base):
-        return type(name, (base,), {})
-
-    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
-    def test_load_plugins_scanner_plugin(
-        self, mock_pkg_resources, mock_import_module, mock_output
-    ):
-        # Setup fake plugin class
-        FakeScannerPlugin = self.make_fake_plugin_base(
-            "FakeScannerPlugin", plugin_manager.ScannerPluginBase
-        )
-
-        # Setup fake entry point
-        fake_entry_point = mock.Mock()
-        fake_entry_point.name = "fake_scanner"
-        fake_entry_point.load.return_value = FakeScannerPlugin
-
-        # Setup pkg_resources
-        mock_pkg_resources.working_set.by_key = {
-            "yawast_plugin_test": None,
-            "other_package": None,
-        }
-        mock_pkg_resources.iter_entry_points.return_value = [fake_entry_point]
-
-        # Setup import_module to return a module with entry_points
-        fake_module = types.SimpleNamespace(entry_points=True)
-        mock_import_module.return_value = fake_module
-
-        # Clear plugins dict
-        plugin_manager.plugins["scanner"].clear()
-        plugin_manager.plugins["hook"].clear()
-
-        plugin_manager.load_plugins()
-
-        # Assert plugin loaded as scanner
-        assert "fake_scanner" in plugin_manager.plugins["scanner"]
-        assert plugin_manager.plugins["scanner"]["fake_scanner"] is FakeScannerPlugin
-
-    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
-    def test_load_plugins_hook_plugin(
-        self, mock_pkg_resources, mock_import_module, mock_output
-    ):
-        # Setup fake plugin class
-        FakeHookPlugin = self.make_fake_plugin_base(
-            "FakeHookPlugin", plugin_manager.HookScannerBase
-        )
-
-        # Setup entry point
-        fake_entry_point = mock.Mock()
-        fake_entry_point.name = "fake_hook"
-        fake_entry_point.load.return_value = FakeHookPlugin
-
-        # Setup pkg_resources
-        mock_pkg_resources.working_set.by_key = {
-            "yawast_plugin_hook": None,
-        }
-        mock_pkg_resources.iter_entry_points.return_value = [fake_entry_point]
-
-        # Setup import_module to return a module with entry_points
-        fake_module = types.SimpleNamespace(entry_points=True)
-        mock_import_module.return_value = fake_module
-
-        # Clear plugins dict
-        plugin_manager.plugins["scanner"].clear()
-        plugin_manager.plugins["hook"].clear()
-
-        plugin_manager.load_plugins()
-
-        # Assert plugin loaded as hook
-        assert "fake_hook" in plugin_manager.plugins["hook"]
-        assert plugin_manager.plugins["hook"]["fake_hook"] is FakeHookPlugin
-
-    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
-    def test_load_plugins_non_plugin_class(
-        self, mock_pkg_resources, mock_import_module, mock_output
-    ):
-        # Setup fake class not inheriting from PluginBase
-        class NotAPlugin:
-            pass
-
-        fake_entry_point = mock.Mock()
-        fake_entry_point.name = "not_a_plugin"
-        fake_entry_point.load.return_value = NotAPlugin
-
-        mock_pkg_resources.working_set.by_key = {
-            "yawast_plugin_invalid": None,
-        }
-        mock_pkg_resources.iter_entry_points.return_value = [fake_entry_point]
-
-        fake_module = types.SimpleNamespace(entry_points=True)
-        mock_import_module.return_value = fake_module
-
-        plugin_manager.plugins["scanner"].clear()
-        plugin_manager.plugins["hook"].clear()
-
-        plugin_manager.load_plugins()
-
-        # Should not be loaded
-        assert "not_a_plugin" not in plugin_manager.plugins["scanner"]
-        assert "not_a_plugin" not in plugin_manager.plugins["hook"]
-
-    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
-    def test_load_plugins_import_error(
-        self, mock_pkg_resources, mock_import_module, mock_output
-    ):
-        mock_pkg_resources.working_set.by_key = {
-            "yawast_plugin_broken": None,
-        }
-        mock_import_module.side_effect = Exception("Import failed")
-
-        plugin_manager.plugins["scanner"].clear()
-        plugin_manager.plugins["hook"].clear()
-
-        with utils.capture_sys_output() as (stdout, stderr):
-            plugin_manager.load_plugins()
-
-            self.assertIn(
-                "Failed to load package yawast_plugin_broken: Import failed",
-                stdout.getvalue(),
-            )
-
-        assert not plugin_manager.plugins["scanner"]
-        assert not plugin_manager.plugins["hook"]
-
-    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.importlib.import_module")
-    @mock.patch("yawast.scanner.plugins.plugin_manager.pkg_resources")
-    def test_load_plugins_no_entry_points(
-        self, mock_pkg_resources, mock_import_module, mock_output
-    ):
-        mock_pkg_resources.working_set.by_key = {
-            "yawast_plugin_noentry": None,
-        }
-        fake_module = types.SimpleNamespace()
-        mock_import_module.return_value = fake_module
-
-        plugin_manager.plugins["scanner"].clear()
-        plugin_manager.plugins["hook"].clear()
-
-        plugin_manager.load_plugins()
-
-        # Should not call iter_entry_points or debug
-        mock_output.debug.assert_not_called()
-
     @mock.patch("builtins.print")
     def test_print_loaded_plugins_with_plugins(self, mock_print):
         # Setup fake plugin classes
@@ -193,63 +41,26 @@ class TestPluginLoader(TestCase):
         plugin_manager.print_loaded_plugins()
 
         # Should print headers and a blank line, but no plugins
-        expected_calls = [
+        unexpected_calls = [
             mock.call("Loaded scanner plugins:"),
             mock.call("Loaded hook plugins:"),
-            mock.call(),
         ]
-        mock_print.assert_has_calls(expected_calls, any_order=False)
 
-    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
-    def test_run_http_scans_runs_non_http_plugins(self, mock_output):
-        # Setup a plugin that does NOT inherit from HttpScannerPluginBase
-        class FakeScanner(plugin_manager.ScannerPluginBase):
-            def __init__(self):
-                self.checked = False
-
-            def check(self):
-                self.checked = True
-                mock_output.debug("checked")
-
-        fake_plugin = FakeScanner
-        plugin_manager.plugins["scanner"].clear()
-        plugin_manager.plugins["scanner"]["fake"] = fake_plugin
-
-        plugin_manager.run_http_scans()
-
-        # Should call check and output.debug for start and completion
-        mock_output.debug.assert_any_call("Running scanner plugins...")
-        mock_output.debug.assert_any_call("Plugin fake completed successfully.")
-        # Should not call output.error
-        mock_output.error.assert_not_called()
-
-    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
-    def test_run_http_scans_skips_http_plugins(self, mock_output):
-        # Setup a plugin that DOES inherit from HttpScannerPluginBase
-        class FakeHttpScanner(plugin_manager.HttpScannerPluginBase):
-            def check(self):
-                raise Exception("Should not be called")
-
-        plugin_manager.plugins["scanner"].clear()
-        plugin_manager.plugins["scanner"]["http"] = FakeHttpScanner
-
-        plugin_manager.run_http_scans()
-
-        # Should not call check, so no error
-        mock_output.error.assert_not_called()
-        mock_output.debug.assert_any_call("Running scanner plugins...")
+        # make sure no unexpected calls were made
+        for call in unexpected_calls:
+            assert call not in mock_print.call_args_list
 
     @mock.patch("yawast.scanner.plugins.plugin_manager.output")
     def test_run_http_scans_handles_plugin_exception(self, mock_output):
         # Setup a plugin that raises in check
-        class FailingScanner(plugin_manager.ScannerPluginBase):
-            def check(self):
+        class FailingScanner(plugin_manager.HttpScannerPluginBase):
+            def check(self, url):
                 raise ValueError("fail!")
 
         plugin_manager.plugins["scanner"].clear()
         plugin_manager.plugins["scanner"]["fail"] = FailingScanner
 
-        plugin_manager.run_http_scans()
+        plugin_manager.run_http_scans("https://example.com")
 
         # Should call output.error with the exception message
         mock_output.error.assert_any_call(
@@ -264,7 +75,7 @@ class TestPluginLoader(TestCase):
     @mock.patch("yawast.scanner.plugins.plugin_manager.output")
     def test_run_http_scans_no_scanner_plugins(self, mock_output):
         plugin_manager.plugins["scanner"].clear()
-        plugin_manager.run_http_scans()
+        plugin_manager.run_http_scans("https://example.com")
         # Should not call output.debug or output.error
         mock_output.debug.assert_not_called()
         mock_output.error.assert_not_called()
@@ -276,7 +87,7 @@ class TestPluginLoader(TestCase):
             def __init__(self):
                 self.checked = False
 
-            def check(self):
+            def check(self, url):
                 self.checked = True
                 mock_output.debug("checked network")
 
@@ -284,7 +95,7 @@ class TestPluginLoader(TestCase):
         plugin_manager.plugins["scanner"].clear()
         plugin_manager.plugins["scanner"]["net"] = fake_plugin
 
-        plugin_manager.run_network_scans()
+        plugin_manager.run_network_scans("https://example.com")
 
         # Should call check and output.debug for start and completion
         mock_output.debug.assert_any_call("Running network scanner plugins...")
@@ -301,7 +112,7 @@ class TestPluginLoader(TestCase):
         plugin_manager.plugins["scanner"].clear()
         plugin_manager.plugins["scanner"]["not_net"] = FakeScanner
 
-        plugin_manager.run_network_scans()
+        plugin_manager.run_network_scans("https://example.com")
 
         # Should not call check, so no error
         mock_output.error.assert_not_called()
@@ -317,7 +128,7 @@ class TestPluginLoader(TestCase):
         plugin_manager.plugins["scanner"].clear()
         plugin_manager.plugins["scanner"]["fail_net"] = FailingNetworkScanner
 
-        plugin_manager.run_network_scans()
+        plugin_manager.run_network_scans("https://example.com")
 
         # Should call output.error with the exception message
         mock_output.error.assert_any_call(
@@ -332,7 +143,115 @@ class TestPluginLoader(TestCase):
     @mock.patch("yawast.scanner.plugins.plugin_manager.output")
     def test_run_network_scans_no_scanner_plugins(self, mock_output):
         plugin_manager.plugins["scanner"].clear()
-        plugin_manager.run_network_scans()
+        plugin_manager.run_network_scans("https://example.com")
         # Should not call output.debug or output.error
         mock_output.debug.assert_not_called()
         mock_output.error.assert_not_called()
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.entry_points")
+    def test_load_plugins_loads_scanner_and_hook_plugins(
+        self, mock_entry_points, mock_output
+    ):
+        # Setup fake plugin classes
+        class FakeScannerPlugin(plugin_manager.ScannerPluginBase):
+            pass
+
+        class FakeHookPlugin(plugin_manager.HookScannerBase):
+            pass
+
+        # Setup fake entry points
+        fake_scanner_ep = mock.Mock()
+        fake_scanner_ep.name = "scanner_plugin"
+        fake_scanner_ep.load.return_value = FakeScannerPlugin
+
+        fake_hook_ep = mock.Mock()
+        fake_hook_ep.name = "hook_plugin"
+        fake_hook_ep.load.return_value = FakeHookPlugin
+
+        mock_entry_points.return_value = [fake_scanner_ep, fake_hook_ep]
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.load_plugins()
+
+        # Scanner plugin should be loaded under "scanner"
+        assert "scanner_plugin" in plugin_manager.plugins["scanner"]
+        assert plugin_manager.plugins["scanner"]["scanner_plugin"] is FakeScannerPlugin
+
+        # Hook plugin should be loaded under "hook"
+        assert "hook_plugin" in plugin_manager.plugins["hook"]
+        assert plugin_manager.plugins["hook"]["hook_plugin"] is FakeHookPlugin
+
+        # Debug output should be called for both
+        mock_output.debug.assert_any_call("Loaded plugin: scanner_plugin (scanner)")
+        mock_output.debug.assert_any_call("Loaded plugin: hook_plugin (hook)")
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.entry_points")
+    def test_load_plugins_skips_non_pluginbase(self, mock_entry_points, mock_output):
+        # Setup a class that does not inherit from PluginBase
+        class NotAPlugin:
+            pass
+
+        fake_ep = mock.Mock()
+        fake_ep.name = "not_a_plugin"
+        fake_ep.load.return_value = NotAPlugin
+
+        mock_entry_points.return_value = [fake_ep]
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.load_plugins()
+
+        # Should not be loaded
+        assert "not_a_plugin" not in plugin_manager.plugins["scanner"]
+        assert "not_a_plugin" not in plugin_manager.plugins["hook"]
+        mock_output.debug.assert_not_called()
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.entry_points")
+    def test_load_plugins_handles_load_exception(self, mock_entry_points, mock_output):
+        fake_ep = mock.Mock()
+        fake_ep.name = "bad_plugin"
+        fake_ep.load.side_effect = RuntimeError("load failed")
+
+        mock_entry_points.return_value = [fake_ep]
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.load_plugins()
+
+        # Should not be loaded
+        assert "bad_plugin" not in plugin_manager.plugins["scanner"]
+        assert "bad_plugin" not in plugin_manager.plugins["hook"]
+        # Should call output.error
+        mock_output.error.assert_any_call(mock.ANY)
+        mock_output.debug.assert_not_called()
+
+    @mock.patch("yawast.scanner.plugins.plugin_manager.output")
+    @mock.patch("yawast.scanner.plugins.plugin_manager.entry_points")
+    def test_load_plugins_handles_issubclass_exception(
+        self, mock_entry_points, mock_output
+    ):
+        # Setup a plugin whose issubclass check will fail (not a class)
+        fake_ep = mock.Mock()
+        fake_ep.name = "broken_plugin"
+        fake_ep.load.return_value = object()  # not a class
+
+        mock_entry_points.return_value = [fake_ep]
+
+        plugin_manager.plugins["scanner"].clear()
+        plugin_manager.plugins["hook"].clear()
+
+        plugin_manager.load_plugins()
+
+        # Should not be loaded
+        assert "broken_plugin" not in plugin_manager.plugins["scanner"]
+        assert "broken_plugin" not in plugin_manager.plugins["hook"]
+        # Should call output.error
+        mock_output.error.assert_any_call(mock.ANY)
+        mock_output.debug.assert_not_called()

--- a/yawast/commands/scan.py
+++ b/yawast/commands/scan.py
@@ -6,6 +6,7 @@ import socket
 
 from yawast.commands import utils as cutils
 from yawast.scanner.cli import dns, http, network, ssl_internal, ssl_labs, ssl_sweet32
+from yawast.scanner.plugins import plugin_manager
 from yawast.scanner.session import Session
 from yawast.shared import output, utils
 
@@ -63,6 +64,9 @@ def start(session: Session):
             ssl_sweet32.scan(session)
 
     http.scan(session)
+
+    # run any other pluging, that don't fall into the Http or Network categories
+    plugin_manager.run_other_scans(session.url)
 
     # reset any stored data
     http.reset()

--- a/yawast/main.py
+++ b/yawast/main.py
@@ -25,6 +25,7 @@ from yawast.external.get_char import getchar
 from yawast.external.memory_size import Size
 from yawast.external.spinner import Spinner
 from yawast.reporting import reporter
+from yawast.scanner.plugins import plugin_manager
 from yawast.shared import network, output, utils
 
 _start_time = datetime.now()
@@ -133,6 +134,11 @@ def print_header():
     )
     output.print_color(Fore.CYAN, " " + _get_version_info())
     print()
+
+    # load plugins, and print the list of loaded plugins
+    plugin_manager.load_plugins()
+    plugin_manager.print_loaded_plugins()
+
     print(f" Started at {start_time}")
     print("")
 

--- a/yawast/scanner/cli/http.py
+++ b/yawast/scanner/cli/http.py
@@ -34,6 +34,7 @@ from yawast.scanner.modules.http.servers import (
     nginx,
     php,
 )
+from yawast.scanner.plugins import plugin_manager
 from yawast.scanner.session import Session
 from yawast.shared import network, output, utils
 
@@ -206,6 +207,9 @@ def scan(session: Session):
             res += wordpress.check_path_disclosure(wp_path)
         if res:
             reporter.display_results(res, "\t")
+
+    # run the scanning plugins
+    plugin_manager.run_http_scans(session.url)
 
 
 def reset():

--- a/yawast/scanner/cli/network.py
+++ b/yawast/scanner/cli/network.py
@@ -8,6 +8,7 @@ from yawast.external.spinner import Spinner
 from yawast.reporting import reporter
 from yawast.scanner.modules.dns import basic
 from yawast.scanner.modules.network import port_scan
+from yawast.scanner.plugins import plugin_manager
 from yawast.scanner.session import Session
 from yawast.shared import output
 
@@ -15,6 +16,9 @@ from yawast.shared import output
 def scan(session: Session):
     if session.args.ports:
         _check_open_ports(session.domain, session.url)
+
+    # run the scanning plugins
+    plugin_manager.run_network_scans(session.url)
 
 
 def _check_open_ports(domain: str, url: str, file: Optional[str] = None):

--- a/yawast/scanner/plugins/__init__.py
+++ b/yawast/scanner/plugins/__init__.py
@@ -1,0 +1,3 @@
+#  Copyright (c) 2013 - 2025 Adam Caudill and Contributors.
+#  This file is part of YAWAST which is released under the MIT license.
+#  See the LICENSE file for full license details.

--- a/yawast/scanner/plugins/hook_scanner_base.py
+++ b/yawast/scanner/plugins/hook_scanner_base.py
@@ -2,6 +2,7 @@
 #  This file is part of YAWAST which is released under the MIT license.
 #  See the LICENSE file for full license details.
 
+from requests import Response
 from yawast.scanner.plugins.plugin_base import PluginBase
 
 
@@ -15,3 +16,9 @@ class HookScannerBase(PluginBase):
         self.name = "HookScannerBase"
         self.description = "Base class for all hook scanners."
         self.version = "1.0.0"
+
+    def response_received(self, url: str, response: Response) -> None:
+        """
+        Called when a response is received.
+        """
+        raise NotImplementedError("Subclasses must implement this method.")

--- a/yawast/scanner/plugins/hook_scanner_base.py
+++ b/yawast/scanner/plugins/hook_scanner_base.py
@@ -1,0 +1,17 @@
+#  Copyright (c) 2013 - 2025 Adam Caudill and Contributors.
+#  This file is part of YAWAST which is released under the MIT license.
+#  See the LICENSE file for full license details.
+
+from yawast.scanner.plugins.plugin_base import PluginBase
+
+
+class HookScannerBase(PluginBase):
+    """
+    Base class for all hook scanners.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "HookScannerBase"
+        self.description = "Base class for all hook scanners."
+        self.version = "1.0.0"

--- a/yawast/scanner/plugins/plugin_base.py
+++ b/yawast/scanner/plugins/plugin_base.py
@@ -1,0 +1,13 @@
+#  Copyright (c) 2013 - 2025 Adam Caudill and Contributors.
+#  This file is part of YAWAST which is released under the MIT license.
+#  See the LICENSE file for full license details.
+
+class PluginBase:
+    """
+    Base class for all plugins.
+    """
+
+    def __init__(self):
+        self.name = "PluginBase"
+        self.description = "Base class for all plugins."
+        self.version = "1.0.0"

--- a/yawast/scanner/plugins/plugin_manager.py
+++ b/yawast/scanner/plugins/plugin_manager.py
@@ -6,6 +6,8 @@ import importlib
 import sys
 from typing import Dict, Type
 
+from requests import Response
+
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
 else:
@@ -125,6 +127,24 @@ def run_other_scans(url: str) -> None:
                     plugin_instance.check(url)
 
                     output.debug(f"Plugin {plugin_name} completed successfully.")
+            except Exception as e:
+                output.error(f"Failed to run plugin {plugin_name}: {e}")
+                continue
+
+
+def run_hook_response_received(url: str, response: Response):
+    """
+    Run all loaded hook plugins.
+    """
+    if "hook" in plugins and len(plugins["hook"]) > 0:
+
+        for plugin_name, plugin_class in plugins["hook"].items():
+            try:
+                # get the plugins that derive from HookScannerBase
+                if issubclass(plugin_class, HookScannerBase):
+                    plugin_instance = plugin_class()
+                    plugin_instance.response_received(url, response)
+
             except Exception as e:
                 output.error(f"Failed to run plugin {plugin_name}: {e}")
                 continue

--- a/yawast/scanner/plugins/plugin_manager.py
+++ b/yawast/scanner/plugins/plugin_manager.py
@@ -1,0 +1,115 @@
+#  Copyright (c) 2013 - 2025 Adam Caudill and Contributors.
+#  This file is part of YAWAST which is released under the MIT license.
+#  See the LICENSE file for full license details.
+
+# this is the loader for plugins, it will check for installed packages that
+# match the naming scheme (yawast_plugin_*) and load them. they are then
+# exposed via dictionary, by type and name. for those that derive from
+# scanner_plugin_base, they will be called during the scan process.
+# for those that derive from hook_scanner_base, they will use the
+# defined hooks to acces the scanner and add their own functionality.
+
+import importlib
+import sys
+from typing import Dict, Type
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
+import pkg_resources
+
+from yawast.scanner.plugins.hook_scanner_base import HookScannerBase
+from yawast.scanner.plugins.plugin_base import PluginBase
+from yawast.scanner.plugins.scanner_plugin_base import (
+    HttpScannerPluginBase,
+    NetworkScannerPluginBase,
+    ScannerPluginBase,
+)
+from yawast.shared import output
+
+# Dictionary to hold all loaded plugins
+plugins: Dict[str, Dict[str, Type[PluginBase]]] = {"scanner": {}, "hook": {}}
+
+
+def load_plugins() -> None:
+    """
+    Load all plugins from installed packages.
+    """
+    discovered_plugins = entry_points(group="yawast.plugins")
+    for entry_point in discovered_plugins:
+        try:
+            # Load the plugin module
+            plugin_module = entry_point.load()
+            # Check if the plugin is a subclass of PluginBase
+            if issubclass(plugin_module, PluginBase):
+                # Add the plugin to the dictionary
+                plugin_type = (
+                    "scanner"
+                    if issubclass(plugin_module, ScannerPluginBase)
+                    else "hook"
+                )
+                plugins[plugin_type][entry_point.name] = plugin_module
+                output.debug(f"Loaded plugin: {entry_point.name} ({plugin_type})")
+        except Exception as e:
+            output.error(f"Failed to load plugin {entry_point.name}: {e}")
+            continue
+
+
+def print_loaded_plugins() -> None:
+    """
+    Print all loaded plugins.
+    """
+    plugin_count = sum(len(plugin_dict) for plugin_dict in plugins.values())
+
+    if plugin_count > 0:
+        for plugin_type, plugin_dict in plugins.items():
+            if len(plugin_dict) == 0:
+                continue
+
+            print(f"Loaded {plugin_type} plugins:")
+            for plugin_name, plugin_class in plugin_dict.items():
+                print(f" - {plugin_name}: {plugin_class.__name__}")
+
+        print()
+
+
+def run_http_scans(url: str) -> None:
+    """
+    Run all loaded scanner plugins.
+    """
+    if "scanner" in plugins and len(plugins["scanner"]) > 0:
+        output.debug("Running scanner plugins...")
+
+        for plugin_name, plugin_class in plugins["scanner"].items():
+            try:
+                # get the plugins that derive from HttpScannerBase
+                if issubclass(plugin_class, HttpScannerPluginBase):
+                    plugin_instance = plugin_class()
+                    plugin_instance.check(url)
+
+                    output.debug(f"Plugin {plugin_name} completed successfully.")
+            except Exception as e:
+                output.error(f"Failed to run plugin {plugin_name}: {e}")
+                continue
+
+
+def run_network_scans(url: str) -> None:
+    """
+    Run all loaded network scanner plugins.
+    """
+    if "scanner" in plugins and len(plugins["scanner"]) > 0:
+        output.debug("Running network scanner plugins...")
+
+        for plugin_name, plugin_class in plugins["scanner"].items():
+            try:
+                # get the plugins that derive from NetworkScannerBase
+                if issubclass(plugin_class, NetworkScannerPluginBase):
+                    plugin_instance = plugin_class()
+                    plugin_instance.check(url)
+
+                    output.debug(f"Plugin {plugin_name} completed successfully.")
+            except Exception as e:
+                output.error(f"Failed to run plugin {plugin_name}: {e}")
+                continue

--- a/yawast/scanner/plugins/plugin_manager.py
+++ b/yawast/scanner/plugins/plugin_manager.py
@@ -2,7 +2,6 @@
 #  This file is part of YAWAST which is released under the MIT license.
 #  See the LICENSE file for full license details.
 
-import importlib
 import sys
 from typing import Dict, Type
 
@@ -12,8 +11,6 @@ if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
 else:
     from importlib.metadata import entry_points
-
-import pkg_resources
 
 from yawast.scanner.plugins.hook_scanner_base import HookScannerBase
 from yawast.scanner.plugins.plugin_base import PluginBase

--- a/yawast/scanner/plugins/plugin_manager.py
+++ b/yawast/scanner/plugins/plugin_manager.py
@@ -113,3 +113,25 @@ def run_network_scans(url: str) -> None:
             except Exception as e:
                 output.error(f"Failed to run plugin {plugin_name}: {e}")
                 continue
+
+
+def run_other_scans(url: str) -> None:
+    """
+    Run all loaded scanner plugins.
+    """
+    if "scanner" in plugins and len(plugins["scanner"]) > 0:
+        output.debug("Running other scanner plugins...")
+
+        for plugin_name, plugin_class in plugins["scanner"].items():
+            try:
+                # get the plugins that derive from ScannerPluginBase
+                if issubclass(plugin_class, ScannerPluginBase) and not issubclass(
+                    plugin_class, (HttpScannerPluginBase, NetworkScannerPluginBase)
+                ):
+                    plugin_instance = plugin_class()
+                    plugin_instance.check(url)
+
+                    output.debug(f"Plugin {plugin_name} completed successfully.")
+            except Exception as e:
+                output.error(f"Failed to run plugin {plugin_name}: {e}")
+                continue

--- a/yawast/scanner/plugins/plugin_manager.py
+++ b/yawast/scanner/plugins/plugin_manager.py
@@ -2,13 +2,6 @@
 #  This file is part of YAWAST which is released under the MIT license.
 #  See the LICENSE file for full license details.
 
-# this is the loader for plugins, it will check for installed packages that
-# match the naming scheme (yawast_plugin_*) and load them. they are then
-# exposed via dictionary, by type and name. for those that derive from
-# scanner_plugin_base, they will be called during the scan process.
-# for those that derive from hook_scanner_base, they will use the
-# defined hooks to acces the scanner and add their own functionality.
-
 import importlib
 import sys
 from typing import Dict, Type

--- a/yawast/scanner/plugins/scanner_plugin_base.py
+++ b/yawast/scanner/plugins/scanner_plugin_base.py
@@ -1,0 +1,59 @@
+#  Copyright (c) 2013 - 2025 Adam Caudill and Contributors.
+#  This file is part of YAWAST which is released under the MIT license.
+#  See the LICENSE file for full license details.
+
+from yawast.scanner.plugins.plugin_base import PluginBase
+
+
+class ScannerPluginBase(PluginBase):
+    """
+    Base class for all scanner plugins.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "ScannerPluginBase"
+        self.description = "Base class for all scanner plugins."
+        self.version = "1.0.0"
+
+    def check(self, url: str) -> None:
+        """
+        Check the given URL for vulnerabilities.
+        """
+        raise NotImplementedError("Subclasses must implement this method.")
+
+
+class HttpScannerPluginBase(ScannerPluginBase):
+    """
+    Base class for all HTTP scanner plugins.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "HttpScannerBase"
+        self.description = "Base class for all HTTP scanner plugins."
+        self.version = "1.0.0"
+
+    def check(self, url: str) -> None:
+        """
+        Check the given URL for vulnerabilities.
+        """
+        raise NotImplementedError("Subclasses must implement this method.")
+
+
+class NetworkScannerPluginBase(ScannerPluginBase):
+    """
+    Base class for all network scanner plugins.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "NetworkScannerBase"
+        self.description = "Base class for all network scanner plugins."
+        self.version = "1.0.0"
+
+    def check(self, url: str) -> None:
+        """
+        Check the given URL for vulnerabilities.
+        """
+        raise NotImplementedError("Subclasses must implement this method.")

--- a/yawast/shared/network.py
+++ b/yawast/shared/network.py
@@ -19,6 +19,7 @@ from validator_collection import checkers
 
 from yawast import config
 from yawast._version import get_version
+from yawast.scanner.plugins import plugin_manager
 from yawast.shared import output, utils
 from yawast.shared.exec_timer import ExecutionTimer
 
@@ -142,6 +143,8 @@ def http_head(
         f"{int(res.elapsed.total_seconds() * 1000)}ms."
     )
 
+    plugin_manager.run_hook_response_received(url, res)
+
     return res
 
 
@@ -159,6 +162,8 @@ def http_options(url: str, timeout: Optional[int] = 30) -> Response:
         f"{res.request.method}: {url} - completed ({res.status_code}) in "
         f"{int(res.elapsed.total_seconds() * 1000)}ms."
     )
+
+    plugin_manager.run_hook_response_received(url, res)
 
     return res
 
@@ -217,6 +222,8 @@ def http_get(
         f"(Body: {len(res.content)})"
     )
 
+    plugin_manager.run_hook_response_received(url, res)
+
     return res
 
 
@@ -251,6 +258,8 @@ def http_put(
         f"(Body: {len(res.content)})"
     )
 
+    plugin_manager.run_hook_response_received(url, res)
+
     return res
 
 
@@ -277,6 +286,8 @@ def http_custom(
         f"{int(res.elapsed.total_seconds() * 1000)}ms "
         f"(Body: {len(res.content)})"
     )
+
+    plugin_manager.run_hook_response_received(url, res)
 
     return res
 


### PR DESCRIPTION
This adds support for loading plugins into yawast-ng, using the packages installed in the environment, checking the package entry points. Allowing users to install a normal Python package, and it just works.

Fixes #19 