### PR TITLE
Check PHP version in X-Powered-By header

### DIFF
--- a/yawast/scanner/modules/http/servers/php.py
+++ b/yawast/scanner/modules/http/servers/php.py
@@ -73,6 +73,9 @@ def find_phpinfo(links: List[str]) -> List[Result]:
                 )
             )
 
+        # check for version in the banner
+        results += check_version(res.headers.get("X-Powered-By", ""), res.text, url)
+
     targets = ["phpinfo.php", "info.php", "version.php", "x.php"]
 
     for link in links:


### PR DESCRIPTION
Adds logic to detect the PHP version from the X-Powered-By header in HTTP responses when scanning for phpinfo pages.