### PR TITLE
Add scan complete hook for plugins

### DIFF
--- a/sample-plugin/plugin/sample_plugin.py
+++ b/sample-plugin/plugin/sample_plugin.py
@@ -60,3 +60,8 @@ class SampleHookPlugin(HookScannerBase):
         # This is where your injection point logic goes.
         # For demonstration, we'll just print a message if an injection point is found.
         output.info(f"SampleHookPlugin found injection point: {url} ({point})")
+
+    def scan_complete(self, session):
+        # This is where your logic for when the scan is complete goes.
+        # For demonstration, we'll just print a message.
+        output.info(f"SampleHookPlugin scan complete for session: {session.url}")

--- a/tests/test_hook_scan_complete.py
+++ b/tests/test_hook_scan_complete.py
@@ -1,0 +1,38 @@
+from unittest import mock
+
+import pytest
+
+import yawast.scanner.plugins.plugin_manager as plugin_manager
+from yawast.scanner.session import Session
+
+
+class DummyHook(plugin_manager.HookScannerBase):
+    called = False
+
+    def __init__(self):
+        super().__init__()
+
+    def scan_complete(self, session):
+        DummyHook.called = True
+
+
+class DummyHookError(plugin_manager.HookScannerBase):
+    def scan_complete(self, session):
+        raise Exception("fail")
+
+
+def test_run_hook_scan_complete_calls_scan_complete(monkeypatch):
+    DummyHook.called = False
+    plugin_manager.plugins["hook"] = {"dummy": DummyHook}
+    session = mock.Mock(spec=Session)
+    plugin_manager.run_hook_scan_complete(session)
+    assert DummyHook.called is True
+
+
+def test_run_hook_scan_complete_handles_exception(monkeypatch):
+    plugin_manager.plugins["hook"] = {"error": DummyHookError}
+    session = mock.Mock(spec=Session)
+    errors = []
+    monkeypatch.setattr(plugin_manager.output, "error", lambda x: errors.append(x))
+    plugin_manager.run_hook_scan_complete(session)
+    assert any("Failed to run plugin error" in e for e in errors)

--- a/yawast/scanner/cli/http.py
+++ b/yawast/scanner/cli/http.py
@@ -235,6 +235,9 @@ def scan(session: Session):
     # run the scanning plugins
     plugin_manager.run_http_scans(session.url)
 
+    # run the scan complete hook
+    plugin_manager.run_hook_scan_complete(session)
+
 
 def reset():
     retirejs.reset()

--- a/yawast/scanner/plugins/hook_scanner_base.py
+++ b/yawast/scanner/plugins/hook_scanner_base.py
@@ -6,6 +6,7 @@ from requests import Response
 
 from yawast.reporting.injection import InjectionPoint
 from yawast.scanner.plugins.plugin_base import PluginBase
+from yawast.scanner.session import Session
 
 
 class HookScannerBase(PluginBase):
@@ -33,5 +34,11 @@ class HookScannerBase(PluginBase):
         :param url: The URL being scanned
         :param point: The injection point found
         :param response: The HTTP response associated with the injection point
+        """
+        pass
+
+    def scan_complete(self, session: Session) -> None:
+        """
+        Called when the scan is complete.
         """
         pass

--- a/yawast/scanner/plugins/plugin_manager.py
+++ b/yawast/scanner/plugins/plugin_manager.py
@@ -7,6 +7,8 @@ from typing import Dict, Type
 
 from requests import Response
 
+from yawast.scanner.session import Session
+
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
 else:
@@ -162,6 +164,21 @@ def run_hook_injection_point_found(url: str, point: InjectionPoint, response: Re
                 if issubclass(plugin_class, HookScannerBase):
                     plugin_instance = plugin_class()
                     plugin_instance.injection_point_found(url, point, response)
+            except Exception as e:
+                output.error(f"Failed to run plugin {plugin_name}: {e}")
+                continue
+
+def run_hook_scan_complete(session: Session):
+    """
+    Run all loaded hook plugins when the scan is complete.
+    """
+    if "hook" in plugins and len(plugins["hook"]) > 0:
+        for plugin_name, plugin_class in plugins["hook"].items():
+            try:
+                # get the plugins that derive from HookScannerBase
+                if issubclass(plugin_class, HookScannerBase):
+                    plugin_instance = plugin_class()
+                    plugin_instance.scan_complete(session)
             except Exception as e:
                 output.error(f"Failed to run plugin {plugin_name}: {e}")
                 continue


### PR DESCRIPTION
Introduces a scan_complete method to HookScannerBase and updates plugin_manager to call this hook after scanning. Adds a sample implementation and tests to ensure scan_complete is called and errors are handled.